### PR TITLE
Ensure applications are started

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ clean:
 	$(REBAR) clean
 	make -C rel/deb clean
 
+rel: update
+	$(REBAR) as prod release
+
 deb-clean:
 	make -C rel/deb clean
 

--- a/apps/ddb_proxy/src/ddb_proxy.app.src
+++ b/apps/ddb_proxy/src/ddb_proxy.app.src
@@ -13,7 +13,8 @@
     dp_decoder,
     dqe_idx,
     dqe_idx_pg,
-    ddb_client
+    ddb_client,
+    trie
    ]},
   {env,[]},
   {modules, []},

--- a/apps/ddb_proxy/src/ddb_proxy.app.src
+++ b/apps/ddb_proxy/src/ddb_proxy.app.src
@@ -14,7 +14,8 @@
     dqe_idx,
     dqe_idx_pg,
     ddb_client,
-    trie
+    trie,
+    jsone
    ]},
   {env,[]},
   {modules, []},


### PR DESCRIPTION
New idx gen_server won't start on a clean install without starting the trie application.
